### PR TITLE
ft_013 - Colocar a TabBar no lugar certo

### DIFF
--- a/src/Rotas.js
+++ b/src/Rotas.js
@@ -6,6 +6,7 @@ import Login from "./telas/TelaLogin";
 import Home from "./telas/Home"
 import TelaFutMarcado from "./telas/TelaFutMarcado";
 import TelaConfirmados from "./telas/TelaConfirmados";
+import Tabsdois from "./telas/TabsDois";
 
 const StackNavigation = createNativeStackNavigator();
 
@@ -22,6 +23,12 @@ function Rotas() {
                 component={Tabs}
                 options={{ headerShown: false }} 
                 />
+            <StackNavigation.Screen
+                name="Tabsdois"
+                component={Tabsdois}
+                options={{ headerShown: false }} 
+                />
+          
             <StackNavigation.Screen
                 name="Login"
                 component={Login}

--- a/src/telas/Home/index.js
+++ b/src/telas/Home/index.js
@@ -8,7 +8,7 @@ export default function Home( { navigation } ) {
         navigation.navigate('Login')
     }
     const goToFut = () => {
-        navigation.navigate('Tabs')
+        navigation.navigate('Tabsdois')
     }
     const fecharApp = () => {
         

--- a/src/telas/Tabsdois/index.js
+++ b/src/telas/Tabsdois/index.js
@@ -1,0 +1,39 @@
+//esse tabs vai ser o de quem não é adm, sem acesso ao marcar fut, que deve ser uma função só do CAPITÃOimport React from 'react'
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import TelaConfirmados from '../TelaConfirmados';
+import TelaFutMarcado from '../TelaFutMarcado';
+
+const Tab = createBottomTabNavigator();
+
+export default function Tabsdois() {
+  return (
+    <Tab.Navigator
+      tabBarOptions={{
+        activeTintColor: 'white',
+        inactiveTintColor: '#747474',
+        activeBackgroundColor: '#6FAF46',
+        inactiveBackgroundColor: '#242323',
+        style: {
+          height: 10,
+        },
+        labelStyle: {
+          width: '100%',
+          flex: 8,
+          fontWeight: 'bold',
+          fontSize: 16,
+          lineHeight: 15,
+          marginTop: 1,
+          paddingTop: 11,
+          backgroundColor: '#242323'
+        },
+        keyboardHidesTabBar: true //quando clicar nos inputs o teclado vai ficar por cima da TabBar
+      }}>
+  
+
+      <Tab.Screen name="Confirmados" component={TelaConfirmados} options={{ headerShown: false}}/>
+      <Tab.Screen name ="Fut Marcado" component={TelaFutMarcado} options={{ headerShown: false}}/>
+
+    </Tab.Navigator>
+  )
+}
+


### PR DESCRIPTION
A TabBar agora é personalizada para ADM e USUÁRIO

para o adm aparece 3 componentes
para o usercomum aparece apenas 2

o que eu fiz foi criar a TabsDois e chamar ela no botão "vem pro fut" da tela Home, nessa TabsDois não contém o componente de marcar o fut (TelaCadastro)